### PR TITLE
Attempted fix on height: auto not working for iOS/Safari

### DIFF
--- a/style.css
+++ b/style.css
@@ -46,6 +46,7 @@ a:hover::after {
     justify-content: space-between;
     font-size: 0.8rem;
     border-bottom: 2px solid black;
+    max-height: 200px;
 }
 .top-strip img {
     width: 15vw;


### PR DESCRIPTION
- iOS and Safari display the top Trip logo as 100vh essentially
- This is an attempted fix by setting the .top-strip div to max-height of 200px